### PR TITLE
Fix first startup init error (happens only clean registry)

### DIFF
--- a/src/db.cpp
+++ b/src/db.cpp
@@ -234,7 +234,7 @@ CDB::CDB(const char *pszFile, const char* pszMode) :
     pdb(NULL), activeTxn(NULL)
 {
     int ret;
-    if (pszFile == NULL)
+    if (pszFile == NULL || strlen(pszFile) == 0)
         return;
 
     fReadOnly = (!strchr(pszMode, '+') && !strchr(pszMode, 'w'));


### PR DESCRIPTION
I noticed a strange issue - when you start the QT wallet the first time (registry clean) it will crash with an error.

It was something like "St13runtime_error CDB() can't open database file blkindex.dat error".

To reproduce, close wallet - delete registry key "HKEY_CURRENT_USER\Software\VULCANO" and folder "%APPDATA%\VULCANO" and start wallet.

It seems to be fixed in later version of bitcoin, litecoin etc. The background of the issue is probably it should check for an empty string, not an null object. I fixed it the referenced commit.